### PR TITLE
Create workflow to build and publish docker image

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -1,0 +1,33 @@
+name: Docker Image CI
+
+on:
+  push:
+    tags:
+      - v*
+
+env:
+  DOCKER_REPO: pepperonit/rps_server
+
+jobs:
+
+  build_and_publish:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Docker login
+      env:
+        DOCKER_USER: ${{secrets.DOCKER_USER}}
+        DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
+      run: echo "$DOCKER_PASSWORD" | docker login -u $DOCKER_USER --password-stdin
+      
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag ${{env.DOCKER_REPO}}:$GITHUB_REF_NAME --tag ${{env.DOCKER_REPO}}:latest
+      
+    - name: Docker Push
+      run: docker push ${{env.DOCKER_REPO}} --all-tags
+      
+    - name: Docker remove runner config
+      run: rm /home/runner/.docker/config.json


### PR DESCRIPTION
Created a new GitHub Actions workflow to build and publish the Docker image to Docker Hub. The workflow will be triggered once every new release of the repository is made.